### PR TITLE
Support for custom gcv site name

### DIFF
--- a/includes/tripal_linkout.inc
+++ b/includes/tripal_linkout.inc
@@ -93,14 +93,18 @@ function full_gene_linkout_json($genus, $species, $pep_name, $pep_uniquename, $t
     $link =  [];
     global $base_url;
 
-
-    if(getenv("MAIN_TRIPAL_URL")){
-        $gogepp_url = getenv("MAIN_TRIPAL_URL");
+    if(getenv("GCV_SITE_NAME")){
+        $current_gogepp = getenv("GCV_SITE_NAME");
     } else {
         $current_gogepp = 'bipaa';
         if (strpos($base_url, 'bbip.genouest.org') !== false) {
             $current_gogepp = 'bbip';
         }
+    }
+
+    if(getenv("MAIN_TRIPAL_URL")){
+        $gogepp_url = getenv("MAIN_TRIPAL_URL");
+    } else {
         $gogepp_url = 'http://'.$current_gogepp.'.genouest.org';
     }
 


### PR DESCRIPTION
Else it was 'bipaa' by default, even if it's not what's in the docker-compose file
